### PR TITLE
Homebrew changed organisation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,7 +147,7 @@
             <tr><td><a href="http://www.antlr.org/" target="_blank"><strong>ANTLR</strong></a></td></tr>
             <tr><td><a href="http://topcoat.io/" target="_blank"><strong>Topcoat</strong></a></td></tr>
             <tr><td><a href="https://github.com/fabric/fabric" target="_blank"><strong>Python Fabric</strong></a></td></tr>
-            <tr><td><a href="https://github.com/mxcl/homebrew" target="_blank"><strong>Homebrew</strong></a></td></tr>
+            <tr><td><a href="https://github.com/Homebrew/homebrew" target="_blank"><strong>Homebrew</strong></a></td></tr>
             <tr><td><a href="https://github.com/haskell/cabal" target="_blank"><strong>Cabal</strong></a></td></tr>
             <tr><td><a href="https://github.com/diagrams" target="_blank"><strong>Diagrams</strong></a></td></tr>
             <tr><td><a href="http://xmonad.org/" target="_blank"><strong>Xmonad</strong></a></td></tr>


### PR DESCRIPTION
Even though mxcl/homebrew redirects to Homebrew/homebrew, let's keep the correct link.
